### PR TITLE
Обновление пакета grunt-contrib-uglify (проблема с объявлением let)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-htmlmin": "^0.4.0",
     "grunt-contrib-qunit": "^0.7.0",
-    "grunt-contrib-uglify": "^0.9.1",
+    "grunt-contrib-uglify": "^5.0.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^18.0.0",
     "grunt-concurrent": "^2.2.1",


### PR DESCRIPTION
Последняя версия `5.0.1`