### PR TITLE
math.js - an external CAS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,7 @@ module.exports = function(grunt) {
 				files: [
 					{ expand: true, src: ['ext/**'], dest: 'dist/' },
 					{ expand: true, cwd: 'node_modules/ace-builds/src-min/', src: '**/*.js', dest: 'dist/ext/ace/' },
+					{ src: 'node_modules/mathjs/lib/browser/math.js', dest: 'ext/math.js' },
 					{ src: 'node_modules/chas-storage/chasStorage.js', dest: 'dist/ext/chasStorage.js' },
 					{ src: 'node_modules/html2canvas/dist/html2canvas.min.js', dest: 'dist/ext/html2canvas.js' },
 				]

--- a/lib/load.js
+++ b/lib/load.js
@@ -14,6 +14,7 @@
 		'ext/jqplot/plugins/jqplot.barRenderer.min.js',
 		'ext/jqplot/plugins/jqplot.categoryAxisRenderer.min.js',
 		'ext/anyslider/js/jquery.anythingslider.js',
+		choosePath('node_modules/mathjs/lib/browser/math.js', 'ext/math.js'),
 		choosePath('node_modules/html2canvas/dist/html2canvas.min.js', 'ext/html2canvas.js'),
 		'ext/JSCPP.es5.min.js',
 		choosePath('node_modules/chas-storage/chasStorage.js', 'ext/chasStorage.js'),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "ace-builds": "^1.4.12",
     "chas-storage": "^0.1.1",
     "cubic-spline": "^3.0.3",
-    "html2canvas": "^1.0.0-rc.7"
+    "html2canvas": "^1.0.0-rc.7",
+    "mathjs": "^11.5.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
```js
math.simplify('-1*x^2 + (+2)x - 1(x+y)').toTex().replace(/~/g,'');
```
->
```latex
x-\left({ x}^{2}+ y\right)
```
$x-\left({ x}^{2}+ y\right)$

![image](https://user-images.githubusercontent.com/5008131/219144921-0cb6c766-e039-4673-aaa6-396f24a0a942.png)

![image](https://user-images.githubusercontent.com/5008131/219145062-fd2d5ff2-ecf1-4a0a-a486-7bd378320167.png)

Не замена `plusminus()` из коробки, но умеет многое. Иногда слишком многое.

Предлагается сделать эту либу нашей реальностью на ближайшие годы. В конце концов, никто старые функции не убирает.

Весит оно 0.7 МБ. По меркам 2014 это было бы много. По меркам 2023 - пушинка.
