### PR TITLE
Указывать автора шаблона в каталоге

### DIFF
--- a/lib/core_vopr.js
+++ b/lib/core_vopr.js
@@ -29,6 +29,7 @@ window.vopr.podg=function(){
 	window.vopr.txt='';
 	window.vopr.rsh='';
 	window.vopr.kat=[];
+	window.vopr.authors=[];
 	window.vopr.dgn=1;
 	window.vopr.err=0;
 	window.vopr.vrn=window.vopr.vrn_mat;

--- a/sh/katalog.js
+++ b/sh/katalog.js
@@ -47,6 +47,16 @@ function generateHtmlForTask(kat,zdn,masdey){
 			'');
 
 		}
+		if(vopr.authors && vopr.authors.length){
+			rez+=(
+				'<br/>' +
+				'<div class="katalog-authors">' +
+						'Автор' + ('ы').esli(vopr.authors.length > 1) + ': &nbsp;' +
+						vopr.authors.join(', ') +
+				'<div/>'+
+				'<br/>'+
+			'');
+		}
 	}catch(e){
 		console.log(e);
 	}

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -66,6 +66,7 @@ chas2.task = {
 			o.answers = chaslib.toStringsArray('answers' in o ? o.answers : []);
 			o.wrongAnswers = chaslib.toStringsArray((('wrongAnswers' in o) && (o.wrongAnswers !== undefined)) ? o.wrongAnswers : []);
 			// Просто o.answers || [] нельзя - ноль не будет передаваться
+			o.authors = chaslib.toStringsArray(o.authors || o.author || []);
 		},
 
 
@@ -119,6 +120,7 @@ chas2.task = {
 	 * @param {String} analys текст разбора задания
 	 * @param {String|Number|String[]|Number[]} answers правильные ответы
 	 * @param {String|Number|String[]|Number[]} wrongAnswers неправильные ответы
+	 * @param {String|String[]} authors авторы шаблона
 	 * @param {String[]} tags теги
 	 * @param {Function} checkAnswer функция проверки ответа
 	 * @param {Function} draw функция отрисовки
@@ -132,6 +134,7 @@ chas2.task = {
 		window.vopr.rsh = o.analys;
 		window.vopr.ver = o.answers;
 		window.vopr.nev = o.wrongAnswers;
+		window.vopr.authors = o.authors;
 		if (o.checkAnswer) {
 			window.vopr.vrn = o.checkAnswer;
 		}
@@ -159,6 +162,7 @@ chas2.task = {
 			checkAnswer : window.vopr.vrn,
 			draw : window.vopr.dey,
 			tags : {},
+			authors : window.vopr.authors,
 		};
 		chas2.task._.normalizeTask(o);
 		chas2.task._.validateTask(o);

--- a/zdn/matege2022p/9/508911.js
+++ b/zdn/matege2022p/9/508911.js
@@ -87,6 +87,7 @@
 		text: `На рисунке изображён график функции $f(x)=${text.plusminus()}$${`,где числа $a,$ $b$ и $c $ - целые `.esli(text == `ax ^ 2 + bx + c `)}. Найдите $f(${chisl})$.`,
 		answers: answ,
 		analys: `$f(x)=${(a + `x ^ 2 +` + b + `x +` + c).replace('+0x', '').replace('+0', '').plusminus()}$`.plusminus(),
+		authors: ['Александра Суматохина', 'Николай Авдеев'],
 	});
 	chas2.task.modifiers.addCanvasIllustration({
 		width: 300,

--- a/zdn/matege2022p/9/509113.js
+++ b/zdn/matege2022p/9/509113.js
@@ -39,6 +39,7 @@
 		text: `На рисунке изображён график функции $f(x)=k\\sqrt{x}$. Найдите ${find}. `,
 		answers: answ,
 		analys: `$f(x)=${k}\\sqrt{x}$`.plusminus(),
+		author: 'Александра Суматохина',
 	});
 	chas2.task.modifiers.addCanvasIllustration({
 		width: 300,

--- a/zdn/matege2022p/9/50914904.js
+++ b/zdn/matege2022p/9/50914904.js
@@ -102,6 +102,7 @@ retryWhileUndefined(function() {
 			'$. Найдите ' + question + '.',
 		answers: answ,
 		analys: '$f(x)=' + (a.ts() + 'x^3+' + b.ts() + 'x^2+' + c.ts() + 'x+' + d.ts()).plusminus() + '$',
+		authors: ['Александра Суматохина', 'Николай Авдеев'],
 	});
 	chas2.task.modifiers.addCanvasIllustration({
 		width: 300,

--- a/zdn/matege2022p/9/56382403.js
+++ b/zdn/matege2022p/9/56382403.js
@@ -100,6 +100,7 @@ retryWhileUndefined(function() {
 			'$, где числа $b$, $c$ и $k$ — целые, $k' + sign[0] + '0$, $b' + sign[1] + '0$. Найдите ' + question + '.',
 		answers: answ,
 		analys: '$f(x)=|' + (k + 'x+' + b + '|+' + c).plusminus() + '$',
+		authors: ['Александра Суматохина'],
 	});
 	chas2.task.modifiers.addCanvasIllustration({
 		width: 300,


### PR DESCRIPTION
Выглядит это вот так:
![image](https://user-images.githubusercontent.com/5008131/229911477-4ca7159e-a239-4311-9930-9c58602c28f3.png)

Себя я приписал демонстрации синтаксиса ради, коммиты со мной - отдельные, не мёржим.

Концептуально нужно для того, чтобы можно было чётко показывать внутри факультета, кто что сделал, чтобы было видно, кто молодец (а кто не очень).