### PR TITLE
[lib][const] Add brand colors as constants

### DIFF
--- a/lib/osnmas.js
+++ b/lib/osnmas.js
@@ -294,3 +294,6 @@ om.edizm.dlina=[
 
 /*TODO: merge with mesiacy*/
 om.months = ['январь','февраль','март','апрель','май','июнь','июль','август','сентябрь','октябрь','ноябрь','декабрь'];
+
+om.primaryBrandColors = ["#D777F2", "#F2A2D6"];
+om.secondaryBrandColors = ["#809DF2"];


### PR DESCRIPTION
К слову об #1156 

Если у нас появляется какая-то константа, которая массово используется в проекте, то она должна быть вынесена в переменную, а не поминаться каждый раз как константа. Потому как всякое бывает, вдруг потребуется изменить фирменные цвета?

Но тут обсуждаемо - что `primary`, а что `secondary`. Возможно, `primaryColor` - в единственном числе и тот, который один. Но это надо думать...