### PR TITLE
[lib][mathjs] Avoid unnecessary brackets

### DIFF
--- a/lib/mathjs_helpers.js
+++ b/lib/mathjs_helpers.js
@@ -22,6 +22,8 @@ var mathjs_helpers = {
 			node instanceof math.ConstantNode
 		||
 			['pow','nthRoot','sqrt','divide'].includes(node.fn)
+		||
+			['pow','nthRoot','sqrt','divide'].includes(node.fn.name)
 		){
 			return innerTeX;
 		}


### PR DESCRIPTION
Иначе оно вот сюда в подлогарифменное выражение лепит скобки
![image](https://github.com/nickkolok/chas-ege/assets/5008131/cdeb3df3-8c43-4dd7-b545-c00651e58fb7)
