### PR TITLE
[zdn][grunt] Fix packing error when a file has no \n at EOF

### DIFF
--- a/src/util/pak.js
+++ b/src/util/pak.js
@@ -37,8 +37,10 @@ module.exports.packZdnSync = function(src, dest) {
 					console.log('Пропускаем файл ' + crrTemplate.full + ' - временный файл мёржа');
 					continue;
 				}
+				buf += '\n';
 				buf += '"' + crrTemplate.name + '" :function(){';
 				buf += fs.readFileSync(crrTemplate.full);
+				buf += '\n';
 				buf += '},';
 			}
 


### PR DESCRIPTION
Если в конце файла нет перевода строки, а в последней строке есть комментарий с `//`  , то при сборке закомменчивался кусок кода и всё падало.