### PR TITLE
Assert sane decimals

### DIFF
--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -914,5 +914,16 @@ chas2.task = {
 			o.analys = o.analys.allDecimalsToStandard(p1);
 			NAtask.setTask(o);
 		},
+
+		/** @function NAtask.modifiers.assertSaneDecimals
+		Вызывает ошибку при наличии слишком длинных десятичных дробей.
+		*/
+		assertSaneDecimals : function() {
+			let o = NAtask.getTask();
+			let insaneDecimal = /(\d|[.,]|\{[.,]\}){8}/;
+			genAssert(!insaneDecimal.test(o.text), 'Текст задания содержит слишком длинные десятичные дроби');
+			genAssert(!insaneDecimal.test(o.analys), 'Решение задания содержит слишком длинные десятичные дроби');
+			genAssert(!insaneDecimal.test(o.answers.join('__')), 'Один из ответов задания содержит слишком длинные десятичные дроби');
+		},
 	},
 };

--- a/zdn/matege2024p/10/26597.js
+++ b/zdn/matege2024p/10/26597.js
@@ -26,6 +26,7 @@
 			answers: v1==1 ? x : x+b,
 			authors: ['Aisse-258']
 		});
+		NAtask.modifiers.assertSaneDecimals();
 		NAtask.modifiers.allDecimalsToStandard();
 	}, 2000000);
 })();


### PR DESCRIPTION
Если вылезают длинные десятичные дроби - надо просто сказать им, чтобы они не вылезали!

```js
> let insaneDecimal = /(\d|[.,]|\{[.,]\}){7}/;
undefined
> insaneDecimal.test('95')
false
> insaneDecimal.test('9.5')
false
> insaneDecimal.test('9.59999999999')
true
> insaneDecimal.test('9,59999999999')
true
> insaneDecimal.test('9{,}59999999999')
true
> insaneDecimal.test('5559{,}599')
true
> insaneDecimal.test('559{,}599')
true
> insaneDecimal.test('559,599')
true
> insaneDecimal.test('559{.}599')
true
> insaneDecimal.test('559{.}99')
false
```