### PR TITLE
[src][fix] .ts() does not produce -0 anymore

### DIFF
--- a/src/chaslib/String_tex.js
+++ b/src/chaslib/String_tex.js
@@ -66,6 +66,9 @@ String.prototype.toStandart = function(wrapComma) {
 	if (wrapComma) {
 		a = ' '+a.replace(/[,]/, '{,}')+' ';
 	}
+	if (a === '-0') {
+		return '0';
+	}
 	return a;
 };
 


### PR DESCRIPTION
Чтобы не было вот такого:

![изображение](https://github.com/user-attachments/assets/b0b02613-39d9-4343-b488-017fb88f468b)

Код взят в https://github.com/nickkolok/chas-ege/pull/2436