### PR TITLE
[src][fix] setEvaluationTask - allow expressions as variable values

### DIFF
--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -585,7 +585,11 @@ chas2.task = {
 		if (o.variables) {
 			// TODO: честная символьная подстановка!
 			for (let v in o.variables) {
-				variableValues[v] = math.parse('' + o.variables[v]).evaluate();
+				if (o.variables[v] === '-0') {
+					o.variables[v] = '0';
+				}
+				o.variables[v] = math.parse('' + o.variables[v]);
+				variableValues[v] = o.variables[v].evaluate();
 			}
 		}
 
@@ -652,8 +656,10 @@ chas2.task = {
 		if (o.variables) {
 			vars = '<br/>при ';
 			for (let v in o.variables) {
-				vars += '$' + v + '=' + math.parse('' + o.variables[v]).toTex() + '$, ';
+				vars += '$' + v + '=' + o.variables[v].toTex() + '$, ';
 			}
+			// В конце перечисления переменных у нас образовалась запятая.
+			// Заменяем её на точку
 			vars = vars.replace(/,\s$/, '.');
 		}
 

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -594,6 +594,7 @@ chas2.task = {
 		}
 
 		let answer = expr.evaluate(variableValues);
+		genAssert(!isNaN(answer), "Ответ не определен. answer: " + answer);
 
 		o.forbiddenAnswers = o.forbiddenAnswers || [];
 		genAssert(!o.forbiddenAnswers.hasElem(answer), 'Ответ находится в списке запрещённых');

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -581,7 +581,15 @@ chas2.task = {
 		let expr = math.parse(o.expr);
 		expr = math.simplify(expr,[mathjs_helpers.slEvaluate]);
 
-		let answer = o.variables ? expr.evaluate(o.variables) : expr.evaluate();
+		let variableValues = {};
+		if (o.variables) {
+			// TODO: честная символьная подстановка!
+			for (let v in o.variables) {
+				variableValues[v] = math.parse(o.variables[v]).evaluate();
+			}
+		}
+
+		let answer = expr.evaluate(variableValues);
 
 		o.forbiddenAnswers = o.forbiddenAnswers || [];
 		genAssert(!o.forbiddenAnswers.hasElem(answer), 'Ответ находится в списке запрещённых');

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -585,7 +585,7 @@ chas2.task = {
 		if (o.variables) {
 			// TODO: честная символьная подстановка!
 			for (let v in o.variables) {
-				variableValues[v] = math.parse(o.variables[v]).evaluate();
+				variableValues[v] = math.parse('' + o.variables[v]).evaluate();
 			}
 		}
 


### PR DESCRIPTION
Тестовый как-бы-шаблон для проверки:

```js
(function() {
	retryWhileError(function() {
		'use strict';

		NAtask.setEvaluationTask({
			expr: 'a^sl(4,21) * divideColon(a^' + sl(4,21).pm() + ',a^sl(4,21))',
			variables: {a : "1/2"},
			authors: ['Николай Авдеев'],
		});
	}, 100);
})();
```