### PR TITLE
Dedicated shuffling in setEvaluationTask

### DIFF
--- a/lib/mathjs_helpers.js
+++ b/lib/mathjs_helpers.js
@@ -84,75 +84,118 @@ var mathjs_helpers = {
 // TODO: possibly that should be a separate library
 const mathjs_shuffle = {
 	shuffleArray(array) {
-	  for (let i = array.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1));
-		[array[i], array[j]] = [array[j], array[i]];
-	  }
-	},
-  
-	flattenAdditions(node) {
-	  if (node.type === 'OperatorNode' && node.op === '+') {
-		// Flatten left and right args recursively
-		let left = this.flattenAdditions(node.args[0]);
-		let right = this.flattenAdditions(node.args[1]);
-		return left.concat(right);
-	  } else {
-		return [node];
-	  }
-	},
-  
-	buildAdditionTree(nodes) {
-	  if (nodes.length === 0) {
-		// No summands, return zero node
-		return new math.ConstantNode(0);
-	  }
-	  if (nodes.length === 1) {
-		return nodes[0];
-	  }
-	  // Build tree by combining first two nodes, then combining result with next, etc.
-	  let tree = new math.OperatorNode('+', 'add', [nodes[0], nodes[1]]);
-	  for (let i = 2; i < nodes.length; i++) {
-		tree = new math.OperatorNode('+', 'add', [tree, nodes[i]]);
-	  }
-	  return tree;
-	},
-  
-	shuffleSummands(node) {
-	  if (node.type === 'OperatorNode' && node.op === '+') {
-		// Flatten all summands
-		let summands = this.flattenAdditions(node);
-		// Recursively shuffle inside each summand first
-		summands = summands.map(s => this.shuffleSummands(s));
-		// Shuffle summands
-		this.shuffleArray(summands);
-		// Rebuild addition tree
-		return this.buildAdditionTree(summands);
-	  } else if (node.args && node.args.length > 0) {
-		// Recursively process children and rebuild node
-		const newArgs = node.args.map(arg => this.shuffleSummands(arg));
-  
-		switch (node.type) {
-		  case 'FunctionNode':
-			return new math.FunctionNode(node.name, newArgs);
-		  case 'OperatorNode':
-			return new math.OperatorNode(node.op, node.fn, newArgs);
-		  case 'ParenthesisNode':
-			return new math.ParenthesisNode(newArgs[0]);
-		  case 'AccessorNode':
-			return new math.AccessorNode(newArgs[0], newArgs[1]);
-		  case 'ArrayNode':
-			return new math.ArrayNode(newArgs);
-		  case 'ConditionalNode':
-			return new math.ConditionalNode(newArgs[0], newArgs[1], newArgs[2]);
-		  default:
-			return node.clone();
+		for (let i = array.length - 1; i > 0; i--) {
+			const j = Math.floor(Math.random() * (i + 1));
+			[array[i], array[j]] = [array[j], array[i]];
 		}
-	  } else {
-		// Leaf node
-		return node;
-	  }
+	},
+
+	// Addition helpers
+	flattenAdditions(node) {
+		if (node.type === 'OperatorNode' && node.op === '+') {
+			let left = this.flattenAdditions(node.args[0]);
+			let right = this.flattenAdditions(node.args[1]);
+			return left.concat(right);
+		} else {
+			return [node];
+		}
+	},
+
+	buildAdditionTree(nodes) {
+		if (nodes.length === 0) {
+			return new math.ConstantNode(0);
+		}
+		if (nodes.length === 1) {
+			return nodes[0];
+		}
+		let tree = new math.OperatorNode('+', 'add', [nodes[0], nodes[1]]);
+		for (let i = 2; i < nodes.length; i++) {
+			tree = new math.OperatorNode('+', 'add', [tree, nodes[i]]);
+		}
+		return tree;
+	},
+
+	shuffleAdditions(node) {
+		if (node.type === 'OperatorNode' && node.op === '+') {
+			let summands = this.flattenAdditions(node);
+			summands = summands.map(s => this.shuffleAdditions(s));
+			this.shuffleArray(summands);
+			return this.buildAdditionTree(summands);
+		} else if (node.args && node.args.length > 0) {
+			const newArgs = node.args.map(arg => this.shuffleAdditions(arg));
+			switch (node.type) {
+				case 'FunctionNode':
+					return new math.FunctionNode(node.name, newArgs);
+				case 'OperatorNode':
+					return new math.OperatorNode(node.op, node.fn, newArgs);
+				case 'ParenthesisNode':
+					return new math.ParenthesisNode(newArgs[0]);
+				case 'AccessorNode':
+					return new math.AccessorNode(newArgs[0], newArgs[1]);
+				case 'ArrayNode':
+					return new math.ArrayNode(newArgs);
+				case 'ConditionalNode':
+					return new math.ConditionalNode(newArgs[0], newArgs[1], newArgs[2]);
+				default:
+					return node.clone();
+			}
+		} else {
+			return node;
+		}
+	},
+
+	// Multiplication helpers
+	flattenMultiplications(node) {
+		if (node.type === 'OperatorNode' && node.op === '*') {
+			let left = this.flattenMultiplications(node.args[0]);
+			let right = this.flattenMultiplications(node.args[1]);
+			return left.concat(right);
+		} else {
+			return [node];
+		}
+	},
+
+	buildMultiplicationTree(nodes) {
+		if (nodes.length === 0) {
+			return new math.ConstantNode(1);
+		}
+		if (nodes.length === 1) {
+			return nodes[0];
+		}
+		let tree = new math.OperatorNode('*', 'multiply', [nodes[0], nodes[1]]);
+		for (let i = 2; i < nodes.length; i++) {
+			tree = new math.OperatorNode('*', 'multiply', [tree, nodes[i]]);
+		}
+		return tree;
+	},
+
+	shuffleMultipliers(node) {
+		if (node.type === 'OperatorNode' && node.op === '*') {
+			let factors = this.flattenMultiplications(node);
+			factors = factors.map(f => this.shuffleMultipliers(f));
+			this.shuffleArray(factors);
+			return this.buildMultiplicationTree(factors);
+		} else if (node.args && node.args.length > 0) {
+			const newArgs = node.args.map(arg => this.shuffleMultipliers(arg));
+			switch (node.type) {
+				case 'FunctionNode':
+					return new math.FunctionNode(node.name, newArgs);
+				case 'OperatorNode':
+					return new math.OperatorNode(node.op, node.fn, newArgs);
+				case 'ParenthesisNode':
+					return new math.ParenthesisNode(newArgs[0]);
+				case 'AccessorNode':
+					return new math.AccessorNode(newArgs[0], newArgs[1]);
+				case 'ArrayNode':
+					return new math.ArrayNode(newArgs);
+				case 'ConditionalNode':
+					return new math.ConditionalNode(newArgs[0], newArgs[1], newArgs[2]);
+				default:
+					return node.clone();
+			}
+		} else {
+			return node;
+		}
 	}
-  };
-  
-  
-  
+};
+

--- a/lib/mathjs_helpers.js
+++ b/lib/mathjs_helpers.js
@@ -196,6 +196,34 @@ const mathjs_shuffle = {
 		} else {
 			return node;
 		}
-	}
+	},
+
+	randomUnaryMinus(node) {
+		if (node.type === 'OperatorNode') {
+			if (node.op === '*') {
+				if (Math.random() < 0.5) {
+					// Flatten all factors
+					let factors = this.flattenMultiplications(node);
+					// Negate only the first factor
+					factors[0] = new math.OperatorNode('-', 'unaryMinus', [factors[0]]);
+					// Rebuild multiplication tree
+					return this.buildMultiplicationTree(factors);
+				}
+				return node;
+			}
+			if (node.op === '/') {
+				if (Math.random() < 0.5) {
+					return new math.OperatorNode('-', 'unaryMinus', [node]);
+				}
+				return node;
+			}
+		}
+		if (node.type === 'FunctionNode') {
+			if (Math.random() < 0.5) {
+				return new math.OperatorNode('-', 'unaryMinus', [node]);
+			}
+		}
+		return node;
+	},
 };
 

--- a/lib/mathjs_helpers.js
+++ b/lib/mathjs_helpers.js
@@ -225,5 +225,36 @@ const mathjs_shuffle = {
 		}
 		return node;
 	},
+
+	// Flip division helper
+	flipDivision(divNode) {
+		return new math.OperatorNode('/', 'divide', [divNode.args[1], divNode.args[0]]);
+	},
+
+	// Randomly flip main fraction at root or unaryMinus wrapping fraction
+	randomFlipMainFraction(node) {
+		if (node.type === 'OperatorNode' && node.op === '/') {
+			if (Math.random() < 0.5) {
+				return this.flipDivision(node);
+			}
+			return node;
+		}
+
+		if (
+			node.type === 'OperatorNode' &&
+			node.op === '-' &&
+			node.fn === 'unaryMinus' &&
+			node.args[0].type === 'OperatorNode' &&
+			node.args[0].op === '/'
+		) {
+			if (Math.random() < 0.5) {
+				const flippedDiv = this.flipDivision(node.args[0]);
+				return new math.OperatorNode('-', 'unaryMinus', [flippedDiv]);
+			}
+			return node;
+		}
+
+		return node;
+	}
 };
 

--- a/lib/mathjs_helpers.js
+++ b/lib/mathjs_helpers.js
@@ -79,3 +79,80 @@ var mathjs_helpers = {
 		return 'not';
 	},
 };
+
+
+// TODO: possibly that should be a separate library
+const mathjs_shuffle = {
+	shuffleArray(array) {
+	  for (let i = array.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[array[i], array[j]] = [array[j], array[i]];
+	  }
+	},
+  
+	flattenAdditions(node) {
+	  if (node.type === 'OperatorNode' && node.op === '+') {
+		// Flatten left and right args recursively
+		let left = this.flattenAdditions(node.args[0]);
+		let right = this.flattenAdditions(node.args[1]);
+		return left.concat(right);
+	  } else {
+		return [node];
+	  }
+	},
+  
+	buildAdditionTree(nodes) {
+	  if (nodes.length === 0) {
+		// No summands, return zero node
+		return new math.ConstantNode(0);
+	  }
+	  if (nodes.length === 1) {
+		return nodes[0];
+	  }
+	  // Build tree by combining first two nodes, then combining result with next, etc.
+	  let tree = new math.OperatorNode('+', 'add', [nodes[0], nodes[1]]);
+	  for (let i = 2; i < nodes.length; i++) {
+		tree = new math.OperatorNode('+', 'add', [tree, nodes[i]]);
+	  }
+	  return tree;
+	},
+  
+	shuffleSummands(node) {
+	  if (node.type === 'OperatorNode' && node.op === '+') {
+		// Flatten all summands
+		let summands = this.flattenAdditions(node);
+		// Recursively shuffle inside each summand first
+		summands = summands.map(s => this.shuffleSummands(s));
+		// Shuffle summands
+		this.shuffleArray(summands);
+		// Rebuild addition tree
+		return this.buildAdditionTree(summands);
+	  } else if (node.args && node.args.length > 0) {
+		// Recursively process children and rebuild node
+		const newArgs = node.args.map(arg => this.shuffleSummands(arg));
+  
+		switch (node.type) {
+		  case 'FunctionNode':
+			return new math.FunctionNode(node.name, newArgs);
+		  case 'OperatorNode':
+			return new math.OperatorNode(node.op, node.fn, newArgs);
+		  case 'ParenthesisNode':
+			return new math.ParenthesisNode(newArgs[0]);
+		  case 'AccessorNode':
+			return new math.AccessorNode(newArgs[0], newArgs[1]);
+		  case 'ArrayNode':
+			return new math.ArrayNode(newArgs);
+		  case 'ConditionalNode':
+			return new math.ConditionalNode(newArgs[0], newArgs[1], newArgs[2]);
+		  default:
+			return node.clone();
+		}
+	  } else {
+		// Leaf node
+		return node;
+	  }
+	}
+  };
+  
+  
+  

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -592,6 +592,9 @@ chas2.task = {
 		if (o.shuffleMultipliers) {
 			expr = mathjs_shuffle.shuffleMultipliers(expr);
 		}
+		if (o.randomUnaryMinus) {
+			expr = mathjs_shuffle.randomUnaryMinus(expr);
+		}
 
 
 		expr = math.simplify(expr,[mathjs_helpers.slEvaluate]);

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -586,6 +586,11 @@ chas2.task = {
 		let task = o.clone();
 
 		let expr = math.parse(o.expr);
+		if (o.shuffleAdditions) {
+			expr = mathjs_shuffle.shuffleAdditions(expr);
+		}
+
+
 		expr = math.simplify(expr,[mathjs_helpers.slEvaluate]);
 
 		let variableValues = {};

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -595,6 +595,9 @@ chas2.task = {
 		if (o.randomUnaryMinus) {
 			expr = mathjs_shuffle.randomUnaryMinus(expr);
 		}
+		if (o.randomFlipMainFraction) {
+			expr = mathjs_shuffle.randomFlipMainFraction(expr);
+		}
 
 
 		expr = math.simplify(expr,[mathjs_helpers.slEvaluate]);

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -589,6 +589,9 @@ chas2.task = {
 		if (o.shuffleAdditions) {
 			expr = mathjs_shuffle.shuffleAdditions(expr);
 		}
+		if (o.shuffleMultipliers) {
+			expr = mathjs_shuffle.shuffleMultipliers(expr);
+		}
 
 
 		expr = math.simplify(expr,[mathjs_helpers.slEvaluate]);

--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -586,19 +586,17 @@ chas2.task = {
 		let task = o.clone();
 
 		let expr = math.parse(o.expr);
-		if (o.shuffleAdditions) {
-			expr = mathjs_shuffle.shuffleAdditions(expr);
-		}
-		if (o.shuffleMultipliers) {
-			expr = mathjs_shuffle.shuffleMultipliers(expr);
-		}
-		if (o.randomUnaryMinus) {
-			expr = mathjs_shuffle.randomUnaryMinus(expr);
-		}
-		if (o.randomFlipMainFraction) {
-			expr = mathjs_shuffle.randomFlipMainFraction(expr);
-		}
 
+		for(let action of[
+			'shuffleAdditions',
+			'shuffleMultipliers',
+			'randomUnaryMinus',
+			'randomFlipMainFraction',
+		]) {
+			if (o[action]) {
+				expr = mathjs_shuffle[action](expr);
+			}
+		}
 
 		expr = math.simplify(expr,[mathjs_helpers.slEvaluate]);
 

--- a/zdn/matege2024b/16/506508.js
+++ b/zdn/matege2024b/16/506508.js
@@ -1,16 +1,16 @@
-﻿
-(function() {
+﻿(function() {
 	retryWhileError(function() {
 		'use strict';
 		let a = sl(2, 10);
 		let b = sl(3, 9);
 		let c = a * b * b;
 		NAtask.setEvaluationTask({
-			expr: slKrome(b, 1, 5).pm() + '/' + b + ['sqrt(' + a + ')', 'sqrt(' + c + ')'].shuffle().join('*'),
+			expr: slKrome(b, 1, 5) + '/' + b + ['sqrt(' + a + ')', 'sqrt(' + c + ')'].shuffle().join('*'),
+			//shuffleMultipliers: true,// Потому как первый множитель должен быть первым!
+			randomUnaryMinus: true,
 			//forbiddenAnswers: [0],
 			authors: ['Алендарь Сергей'],
 		});
 	}, 10000);
 })();
 // 506508
-

--- a/zdn/matege2024b/16/508353.js
+++ b/zdn/matege2024b/16/508353.js
@@ -3,11 +3,11 @@
 		'use strict';
 		let c = sl(2, 9);
 		NAtask.setEvaluationTask({
-			expr: ['(' + c + '^' + sl(1, 9).pm() + ')' + '^' + sl(2, 5).pm(), c + '^' + sl(-15, -2)].shuffle().join('/'),
+			expr: '(' + c + '^' + sl(1, 9).pm() + ')' + '^' + sl(2, 5).pm() + '/' + c + '^' + sl(-15, -2),
+			randomFlipMainFraction: true,
 			//forbiddenAnswers: [0],
 			authors: ['Алендарь Сергей'],
 		});
 	}, 10000);
 })();
 //508353
-

--- a/zdn/matege2024b/16/511955.js
+++ b/zdn/matege2024b/16/511955.js
@@ -4,8 +4,8 @@
 		let a = sl(1.1, 9.9, 0.1);
 		let b = slKrome([a], 1.1, 9.9, 0.1)
 		NAtask.setEvaluationTask({
-			expr: ['(' + a + '*10^2)', '(' + b + '*10^3)'].shuffle().join('+'),
-			//forbiddenAnswers: [0],
+			expr: '' + a + '*10^2 + ' + b + '*10^3',
+			shuffleAdditions: true,
 			authors: ['Алендарь Сергей'],
 		});
 	}, 10000);

--- a/zdn/matege2024b/16/512907.js
+++ b/zdn/matege2024b/16/512907.js
@@ -2,10 +2,9 @@
 	retryWhileError(function() {
 		'use strict';
 		NAtask.setEvaluationTask({
-			expr: [
-				'(' + [0.01, 0.1].iz() + '^' + sl(2, 5) + '/' + '10^' + sl(-1, -5) + ')',
-				'10^' + sl(2, 6)
-				].shuffle().join('*'),
+			expr: '(' + [0.01, 0.1].iz() + '^' + sl(2, 5) + '/' + '10^' + sl(-1, -5) + ')' + 
+				'10^' + sl(2, 6),
+			shuffleMultipliers: true,
 			//forbiddenAnswers: [0],
 			authors: ['Алендарь Сергей'],
 		});


### PR DESCRIPTION
Во многих случаях можно избавиться от `.shuffleJoin('*')` и прилагающегося с нему массива. Должно бы повысить читабельность.