### PR TITLE
[zdn] 317132 - refactor a bit

### DIFF
--- a/zdn/matoge2024/7/317132.js
+++ b/zdn/matoge2024/7/317132.js
@@ -30,7 +30,7 @@
 
 		let value = [valueDrob, valueSqrt][rand];
 		let step = [0.1, 1][rand];
-		let format = rand === 0 ? x => ((x * 10).round() / 10).ts() : x => x;
+		let format = rand === 0 ? x => ((x * 10).round() / 10).ts(true) : x => x;
 
 		let start = Math.floor(value / step) * step;
 		let end = start + step;
@@ -55,7 +55,7 @@
 		NAtask.setTask({
 			text: 'Какому из данных промежутков принадлежит число $' + [exprStrDrob, '\\sqrt{' + numSqrt + '}'][rand] + '$? В ответе укажите номер правильного варианта.',
 			answers: correct,
-			wrongAnswers: Array.from(wrongAnswers),
+			wrongAnswers,
 			preference: preference,
 		});
 


### PR DESCRIPTION
Во-первых, теперь ответы можно передавать как множество, и явное преобразование не нужно.
Во-вторых, `.ts(true)` более красиво ставит десятичные запятые в $\LaTeX$ (рекомендую поковыряться).

@SugarHedgehog , не трогай<s>, это на Новый год</s>.