### PR TITLE
Add IncompatiblePreferencesError and genAssertIncompatiblePreferences()

### DIFF
--- a/lib/func_assert.js
+++ b/lib/func_assert.js
@@ -84,3 +84,19 @@ function genAssertGraphIntersectsPointWithNeighborhood(f, x, y, epsilon, message
 	genAssert(graphNoIntersectionWithSquare(f, x, y, epsilon, 10), 
 	'Функция пересекает точку (' + x + ', ' + y + ') с окрестностью ' + epsilon || message);
 }
+
+function IncompatiblePreferencesError(message) {
+    this.name = 'IncompatiblePreferencesError';
+    this.message = message || 'Несовместимые предпочтения';
+    this.stack = (new Error()).stack;
+}
+IncompatiblePreferencesError.prototype = Object.create(Error.prototype);
+IncompatiblePreferencesError.prototype.constructor = IncompatiblePreferencesError;
+
+function genAssertIncompatiblePreferences(condition, message) {
+    if (!condition) {
+        throw new IncompatiblePreferencesError(
+            message || 'Несовместимые предпочтения'
+        );
+    }
+}


### PR DESCRIPTION
Introduce a dedicated error class so that the outer shell can distinguish incompatible-preferences failures from generic errors via instanceof. The assert helper follows the existing genAssert* pattern in func_assert.js.