### PR TITLE
setCorrespondenceTask: валидация столбцов соответствия

### DIFF
--- a/src/chas2/task.js
+++ b/src/chas2/task.js
@@ -507,6 +507,8 @@ chas2.task = {
 
 	setCorrespondenceTask: function({ left, right, text, leftHeader, rightHeader, postText, autoLaTeXLeft, autoLaTeXRight, preference }) {
 
+		genAssert(new Set(right).size === right.length, 'setCorrespondenceTask: в правом столбце есть повторяющиеся элементы');
+		left.forEach(item => genAssert(right.includes(item.solution), 'setCorrespondenceTask: solution левого элемента отсутствует в правом столбце'));
 		left.shuffle();
 		let shuffledSolutions = [...right].shuffle();
 		let leftCol = '';


### PR DESCRIPTION
В setCorrespondenceTask не было проверок корректности столбцов: дубликаты в правом столбце тихо схлопывали номера (ключ solutionToIndex перезаписывался), а solution левого элемента, отсутствующий в правом, уезжал в ответ как undefined. Добавлены два genAssert в начало метода: элементы правого столбца должны быть попарно различны; каждый solution левого столбца должен присутствовать в правом. Это ломающее изменение для гипотетических задач, которые полагались на дубликаты справа — таких по смыслу соответствия быть не должно, но перед мерджем стоит прогнать генерацию всех задач на соответствие.