### PR TITLE
[lib] array.js: приведение элементов к строке в .tr()

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -70,7 +70,7 @@ Array.prototype.tr=function(p1,p2){
 	var len=this.length-1;
 	var str='';
 	for(;len+1;len--){
-		str=this[len].vTag(p1?p1:'td')+str;
+		str=String(this[len]).vTag(p1?p1:'td')+str;
 	}
 	return str.vTag(p2?p2:'tr');
 }


### PR DESCRIPTION
Исправление ошибки TypeError: this[len].vTag is not a function, возникавшей при передаче чисел в метод `.tr()`. Теперь элементы массива принудительно приводятся к строке.