### PR TITLE
[lib] Добавлена поддержка таблиц в roughHTML2LaTeX

### DIFF
--- a/lib/func.js
+++ b/lib/func.js
@@ -346,6 +346,37 @@ function make2Array(ch,k) {
 
 function roughHTML2LaTeX(str){
 	str = '' + str; // In case if not a string!
+	
+	// Support for HTML tables
+	str = str.replace(/<table[^>]*>([\s\S]*?)<\/table>/gi, function(match, inner) {
+		var rows = inner.match(/<tr[^>]*>[\s\S]*?<\/tr>/gi) || [];
+		if (rows.length === 0) return match;
+		
+		var firstRowCells = rows[0].match(/<t[hd][^>]*>[\s\S]*?<\/t[hd]>/gi) || [];
+		var colCount = firstRowCells.length;
+		if (colCount === 0) return match;
+		
+		var preamble = '|' + Array(colCount).fill('c|').join('');
+		var latex = '\\begin{tabular}{' + preamble + '}\n\\hline\n';
+		
+		rows.forEach(function(row) {
+			var cells = row.match(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/gi) || [];
+			var cellContents = cells.map(function(cell) {
+				return cell.replace(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/i, '$1').trim();
+			});
+			
+			var isHeader = row.toLowerCase().indexOf('<th') !== -1;
+			if (isHeader) {
+				cellContents = cellContents.map(function(c) { return '\\textbf{' + c + '}'; });
+			}
+			
+			latex += cellContents.join(' & ') + ' \\\\\n\\hline\n';
+		});
+		
+		latex += '\\end{tabular}';
+		return latex;
+	});
+
 	str = str.
 		// Escape LaTeX comments,
 		// but don't ruin if they've been already escaped!


### PR DESCRIPTION
## Описание

В функции `roughHTML2LaTeX` (lib/func.js) добавлена поддержка конвертации HTML-таблиц в LaTeX.

Теперь теги `<table>`, `<tr>`, `<td>`, `<th>` корректно преобразуются в LaTeX-таблицу через `\begin{tabular}{|c|c|...|}`. Заголовки `<th>` оборачиваются в `\textbf{}`.

## Проблема

В PR #3267 таблицы в примерах сгенерировались в HTML корректно (через `.vTabl()`), но `roughHTML2LaTeX` не знала, как их конвертировать в LaTeX, из-за чего на GitHub они отображались кривыми.

## Решение

Добавлен парсинг HTML-таблиц и конвертация в LaTeX-формат с правильной преамбулой.