### PR TITLE
[lib] Эксперимент: замена roughHTML2LaTeX на html2latex

### DIFF
--- a/lib/func.js
+++ b/lib/func.js
@@ -345,17 +345,39 @@ function make2Array(ch,k) {
 }
 
 function roughHTML2LaTeX(str) {
-	// Полная замена на вызов библиотеки html2latex
+	// Пробуем использовать готовую библиотеку
 	try {
-		const converter = typeof require !== 'undefined' ? require('html2latex') : (typeof window !== 'undefined' ? window.html2latex : null);
+		const converter = typeof require !== 'undefined' ? require('html2latex') : (typeof window !== 'undefined' && window.html2latex ? window.html2latex : null);
 		if (converter) {
 			return converter(String(str));
 		}
 	} catch (e) {
-		console.warn("html2latex не доступен, используется минимальный фоллбэк", e);
+		console.warn("Библиотека не доступна, используется оригинальная реализация", e);
 	}
-	// Минимальный фоллбэк, чтобы не сломать всё полностью
-	return String(str).replace(/\\?%/g, '\\%').replace(/<br\\/?>/gi, '\\\\').replace(/<b>/gi, '\\textbf{').replace(/<\\/b>/gi, '}').trim();
+	// Оригинальная реализация как фоллбэк
+	str = '' + str; // In case if not a string!
+	str = str.
+		// Escape LaTeX comments,
+		// but don't ruin if they've been already escaped!
+		replace(/\\?%/g, '\\%').
+		replace(/<br>/gi, '\\\\').
+		replace(/<br\/>/gi, '\\\\').
+		replace(/<b>/gi, '\\textbf{').
+		replace(/<\/b>/gi, '}').
+		replace(/\" /g, '"\\space ');
+
+	// Just throw canvases out!
+	str = str.
+		replace(/\n?<canvas/gi, '\n%<canvas').
+		replace(/\n?<\/canvas>/gi, '\n%</canvas>\n%\includegraphics{}\n');
+	// And the same for images!
+	str = str.
+		replace(/\n?<img/gi, '\n%<img').
+		replace(/\n?<\/img>/gi, '\n%</img>\n%\includegraphics{}\n');
+
+	// TODO: treat images, expecially base64-encoded, more rigorously
+
+	return str.trim();
 }
 
 function slLetter(b) {

--- a/lib/func.js
+++ b/lib/func.js
@@ -344,30 +344,18 @@ function make2Array(ch,k) {
 	return x;
 }
 
-function roughHTML2LaTeX(str){
-	str = '' + str; // In case if not a string!
-	str = str.
-		// Escape LaTeX comments,
-		// but don't ruin if they've been already escaped!
-		replace(/\\?%/g, '\\%').
-		replace(/<br>/gi, '\\\\').
-		replace(/<br\/>/gi, '\\\\').
-		replace(/<b>/gi, '\\textbf{').
-		replace(/<\/b>/gi, '}').
-		replace(/\" /g, '"\\space ');
-
-	// Just throw canvases out!
-	str = str.
-		replace(/\n?<canvas/gi, '\n%<canvas').
-		replace(/\n?<\/canvas>/gi, '\n%</canvas>\n%\includegraphics{}\n');
-	// And the same for images!
-	str = str.
-		replace(/\n?<img/gi, '\n%<img').
-		replace(/\n?<\/img>/gi, '\n%</img>\n%\includegraphics{}\n');
-
-	// TODO: treat images, expecially base64-encoded, more rigorously
-
-	return str.trim();
+function roughHTML2LaTeX(str) {
+	// Полная замена на вызов библиотеки html2latex
+	try {
+		const converter = typeof require !== 'undefined' ? require('html2latex') : (typeof window !== 'undefined' ? window.html2latex : null);
+		if (converter) {
+			return converter(String(str));
+		}
+	} catch (e) {
+		console.warn("html2latex не доступен, используется минимальный фоллбэк", e);
+	}
+	// Минимальный фоллбэк, чтобы не сломать всё полностью
+	return String(str).replace(/\\?%/g, '\\%').replace(/<br\\/?>/gi, '\\\\').replace(/<b>/gi, '\\textbf{').replace(/<\\/b>/gi, '}').trim();
 }
 
 function slLetter(b) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chas-ege",
   "version": "2.2.2",
-  "description": "Тренажёр для подготовки к экзаменам",
+  "description": "\u0422\u0440\u0435\u043d\u0430\u0436\u0451\u0440 \u0434\u043b\u044f \u043f\u043e\u0434\u0433\u043e\u0442\u043e\u0432\u043a\u0438 \u043a \u044d\u043a\u0437\u0430\u043c\u0435\u043d\u0430\u043c",
   "main": "index.js",
   "directories": {
     "doc": "doc"
@@ -25,7 +25,8 @@
     "mathjs": "^11.5.1",
     "nerdamer": "^1.1.13",
     "qunit": "^2.26.0",
-    "seedrandom": "^3.0.5"
+    "seedrandom": "^3.0.5",
+    "html2latex": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -59,6 +60,6 @@
     "type": "git",
     "url": "https://bitbucket.org/chas-ege-team/chas-ege/"
   },
-  "author": "Команда проекта Час ЕГЭ",
+  "author": "\u041a\u043e\u043c\u0430\u043d\u0434\u0430 \u043f\u0440\u043e\u0435\u043a\u0442\u0430 \u0427\u0430\u0441 \u0415\u0413\u042d",
   "license": "GPL-3.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chas-ege",
   "version": "2.2.2",
-  "description": "\u0422\u0440\u0435\u043d\u0430\u0436\u0451\u0440 \u0434\u043b\u044f \u043f\u043e\u0434\u0433\u043e\u0442\u043e\u0432\u043a\u0438 \u043a \u044d\u043a\u0437\u0430\u043c\u0435\u043d\u0430\u043c",
+  "description": "Тренажёр для подготовки к экзаменам",
   "main": "index.js",
   "directories": {
     "doc": "doc"
@@ -25,8 +25,8 @@
     "mathjs": "^11.5.1",
     "nerdamer": "^1.1.13",
     "qunit": "^2.26.0",
-    "seedrandom": "^3.0.5",
-    "html2latex": "^1.0.0"
+    "html2latex": "^1.0.0",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -60,6 +60,6 @@
     "type": "git",
     "url": "https://bitbucket.org/chas-ege-team/chas-ege/"
   },
-  "author": "\u041a\u043e\u043c\u0430\u043d\u0434\u0430 \u043f\u0440\u043e\u0435\u043a\u0442\u0430 \u0427\u0430\u0441 \u0415\u0413\u042d",
+  "author": "Команда проекта Час ЕГЭ",
   "license": "GPL-3.0"
 }


### PR DESCRIPTION
Привет! Это первый из двух экспериментальных PR по замене нашей кастомной функции `roughHTML2LaTeX` на готовую NPM-библиотеку.

В этой ветке я подключила пакет `html2latex`. 

Давай сравним, как он справится с нашими таблицами по сравнению с кастомной реализацией и вторым вариантом (`html-to-latex`).