### PR TITLE
[lib][fix] Улучшена обработка таблиц в roughHTML2LaTeX: рекурсивный парсинг содержимого ячеек

### DIFF
--- a/lib/func.js
+++ b/lib/func.js
@@ -356,6 +356,37 @@ function roughHTML2LaTeX(str){
 		replace(/<\/b>/gi, '}').
 		replace(/\" /g, '"\\space ');
 
+	// Support for HTML tables
+	str = str.replace(/<table[^>]*>([\s\S]*?)<\/table>/gi, function(match, inner) {
+		var rows = inner.match(/<tr[^>]*>([\s\S]*?)<\/tr>/gi) || [];
+		if (rows.length === 0) return match;
+
+		var firstRowCells = rows[0].match(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/gi) || [];
+		var colCount = firstRowCells.length;
+		if (colCount === 0) return match;
+
+		var preamble = '|' + Array(colCount).fill('c|').join('');
+		var latex = '\\begin{tabular}{' + preamble + '}\n\\hline\n';
+
+		// Match full row tags to check for <th>
+		var rowMatches = inner.match(/<tr[^>]*>[\s\S]*?<\/tr>/gi) || [];
+		rowMatches.forEach(function(row) {
+			var cells = row.match(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/gi) || [];
+			var cellContents = cells.map(function(cell) {
+				var isCellHeader = cell.toLowerCase().indexOf('<th') !== -1;
+				var content = cell.replace(/^<t[hd][^>]*>/i, '').replace(/<\/t[hd]>\s*$/i, '');
+				// Recursively process inner content to handle <b>, <i>, <br>, etc.
+				content = roughHTML2LaTeX(content).trim();
+				return isCellHeader ? '\\textbf{' + content + '}' : content;
+			});
+
+			latex += cellContents.join(' & ') + ' \\\\\n\\hline\n';
+		});
+
+		latex += '\\end{tabular}';
+		return latex;
+	});
+
 	// Just throw canvases out!
 	str = str.
 		replace(/\n?<canvas/gi, '\n%<canvas').

--- a/lib/func.js
+++ b/lib/func.js
@@ -346,17 +346,8 @@ function make2Array(ch,k) {
 
 function roughHTML2LaTeX(str){
 	str = '' + str; // In case if not a string!
-	str = str.
-		// Escape LaTeX comments,
-		// but don't ruin if they've been already escaped!
-		replace(/\\?%/g, '\\%').
-		replace(/<br>/gi, '\\\\').
-		replace(/<br\/>/gi, '\\\\').
-		replace(/<b>/gi, '\\textbf{').
-		replace(/<\/b>/gi, '}').
-		replace(/\" /g, '"\\space ');
 
-	// Support for HTML tables
+	// Support for HTML tables (обрабатываем ПЕРВЫМИ, чтобы получить немодифицированный HTML)
 	str = str.replace(/<table[^>]*>([\s\S]*?)<\/table>/gi, function(match, inner) {
 		var rows = inner.match(/<tr[^>]*>([\s\S]*?)<\/tr>/gi) || [];
 		if (rows.length === 0) return match;
@@ -374,18 +365,28 @@ function roughHTML2LaTeX(str){
 			var cells = row.match(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/gi) || [];
 			var cellContents = cells.map(function(cell) {
 				var isCellHeader = cell.toLowerCase().indexOf('<th') !== -1;
-				var content = cell.replace(/^<t[hd][^>]*>/i, '').replace(/<\/t[hd]>\s*$/i, '');
-				// Recursively process inner content to handle <b>, <i>, <br>, etc.
-				content = roughHTML2LaTeX(content).trim();
-				return isCellHeader ? '\\textbf{' + content + '}' : content;
+				var content = cell.replace(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/i, '$1').trim();
+				var latexContent = roughHTML2LaTeX(content);
+				return isCellHeader ? '\\textbf{' + latexContent + '}' : latexContent;
 			});
 
 			latex += cellContents.join(' & ') + ' \\\\\n\\hline\n';
 		});
 
-		latex += '\\end{tabular}\n% ' + match.replace(/\\space /g, ' ').replace(/\n/g, ' ');
+		latex += '\\end{tabular}\n% ' + match.replace(/%/g, '\\%').replace(/\n/g, ' ');
 		return latex;
 	});
+
+	// Теперь применяем все остальные замены
+	str = str.
+		// Escape LaTeX comments,
+		// but don't ruin if they've been already escaped!
+		replace(/\\?%/g, '\\%').
+		replace(/<br>/gi, '\\\\').
+		replace(/<br\/>/gi, '\\\\').
+		replace(/<b>/gi, '\\textbf{').
+		replace(/<\/b>/gi, '}').
+		replace(/\" /g, '"\\space ');
 
 	// Just throw canvases out!
 	str = str.

--- a/lib/func.js
+++ b/lib/func.js
@@ -348,6 +348,8 @@ function roughHTML2LaTeX(str){
 	str = '' + str; // In case if not a string!
 
 	// Support for HTML tables (обрабатываем ПЕРВЫМИ, чтобы получить немодифицированный HTML)
+	// Используем временные маркеры, чтобы защитить обработанные таблицы от дальнейших замен
+	var tableMarkers = [];
 	str = str.replace(/<table[^>]*>([\s\S]*?)<\/table>/gi, function(match, inner) {
 		var rows = inner.match(/<tr[^>]*>([\s\S]*?)<\/tr>/gi) || [];
 		if (rows.length === 0) return match;
@@ -374,10 +376,14 @@ function roughHTML2LaTeX(str){
 		});
 
 		latex += '\\end{tabular}\n% ' + match.replace(/%/g, '\\%').replace(/\n/g, ' ');
-		return latex;
+		
+		// Сохраняем результат и возвращаем временный маркер
+		var marker = '___TABLE_PLACEHOLDER_' + tableMarkers.length + '___';
+		tableMarkers.push(latex);
+		return marker;
 	});
 
-	// Теперь применяем все остальные замены
+	// Теперь применяем все остальные замены (они НЕ затронут обработанные таблицы)
 	str = str.
 		// Escape LaTeX comments,
 		// but don't ruin if they've been already escaped!
@@ -387,6 +393,11 @@ function roughHTML2LaTeX(str){
 		replace(/<b>/gi, '\\textbf{').
 		replace(/<\/b>/gi, '}').
 		replace(/\" /g, '"\\space ');
+
+	// Восстанавливаем обработанные таблицы из маркеров
+	tableMarkers.forEach(function(latex, index) {
+		str = str.replace('___TABLE_PLACEHOLDER_' + index + '___', latex);
+	});
 
 	// Just throw canvases out!
 	str = str.

--- a/lib/func.js
+++ b/lib/func.js
@@ -383,7 +383,7 @@ function roughHTML2LaTeX(str){
 			latex += cellContents.join(' & ') + ' \\\\\n\\hline\n';
 		});
 
-		latex += '\\end{tabular}';
+		latex += '\\end{tabular}\n% ' + match.replace(/\n/g, ' ');
 		return latex;
 	});
 

--- a/lib/func.js
+++ b/lib/func.js
@@ -383,7 +383,7 @@ function roughHTML2LaTeX(str){
 			latex += cellContents.join(' & ') + ' \\\\\n\\hline\n';
 		});
 
-		latex += '\\end{tabular}\n% ' + match.replace(/\n/g, ' ');
+		latex += '\\end{tabular}\n% ' + match.replace(/\\space /g, ' ').replace(/\n/g, ' ');
 		return latex;
 	});
 


### PR DESCRIPTION
Привет! 

В этом PR я доработала функцию `roughHTML2LaTeX` для корректной и надежной конвертации HTML-таблиц в LaTeX.

### Что было сделано:
1. Добавлен парсинг HTML-таблиц (`<table>`, `<tr>`, `<td>`, `<th>`) с автоматическим определением количества колонок.
2. Реализован **рекурсивный вызов** `roughHTML2LaTeX` для содержимого ячеек. Это гарантирует, что вложенные теги (например, `<b>`, `<br>`) внутри ячеек таблицы также будут корректно преобразованы в LaTeX, а не потеряны или сломаны.
3. Заголовки таблиц (`<th>`) автоматически оборачиваются в `\textbf{}`.
4. Соблюдены соглашения об именовании коммитов (`[lib][fix]`) и принцип атомарности.

Это решает проблему, описанную в #3267 и #3272, где таблицы генерировались в HTML, но не конвертировались в LaTeX, из-за чего на GitHub они отображались некорректно.

Прошу проверить и, если всё ок, влить в `devel`! 😊