### PR TITLE
fix: downgrade jsdom to 28.1.0 for Node.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "html2canvas": "^1.0.0-rc.7",
     "js-beautify-chas-ege-unofficial-patched": "1.5.3",
     "jscpp-chas-ege-unofficial": "^2.0.2",
-    "jsdom": "^29.1.1",
+    "jsdom": "^28.1.0",
     "jszip": "^3.10.1",
     "mathjax-chas-ege-unofficial": "2.1.0",
     "mathjs": "^11.5.1",


### PR DESCRIPTION
## Описание
Откатил версию `jsdom` с `^29.1.1` до `^28.1.0`.

## Причина
Версия `jsdom@29.1.1` требует Node.js `^20.19.0 || ^22.13.0 || >=24.0.0`.
На текущей версии Node.js (например, `v22.12.0`) возникает предупреждение `EBADENGINE`. Откат позволяет избежать проблем со сборкой без необходимости срочного обновления Node.js у всех разработчиков.

## Изменения
- Обновлён `package.json`: `jsdom` зафиксирован на `^28.1.0`.

## Проверка
Локальная сборка и тесты проходят успешно.