### PR TITLE
fix: корректная обработка пустого вывода при генерации задач

### DIFF
--- a/dev/provide_examples_to_PR.mjs
+++ b/dev/provide_examples_to_PR.mjs
@@ -100,8 +100,28 @@ async function runDebug(filepath, extraArgs) {
 }
 
 function extractLatex(output) {
+    if (output.includes('ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ')) {
+        return 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ';
+    }
     const regex = /=== LaTeX CODE START ===\r?\n([\s\S]*?)\r?\n=== LaTeX CODE END ===/g;
     const matches = [...output.matchAll(regex)];
+    if (matches.length === 0) {
+        return 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ';
+    }
+    
+    for (const m of matches) {
+        const latexBlock = m[1];
+        const textWithoutBoilerplate = latexBlock
+            .replace(/Текст задания:/g, '')
+            .replace(/Ответ:/g, '')
+            .replace(/Решение:/g, '')
+            .trim();
+            
+        if (textWithoutBoilerplate.length === 0) {
+            return 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ';
+        }
+    }
+    
     return matches.map((m, i) => `## Пример ${i + 1}\n\n${m[1].trim()}`).filter(text => text.length > 0).join('\n\n---\n\n');
 }
 
@@ -286,6 +306,7 @@ async function main() {
                     examples.push({ filename: file.filename, text: latex });
                 } else {
                     console.warn(`No LaTeX code found for ${file.filename}`);
+                    examples.push({ filename: file.filename, text: 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ' });
                 }
             } catch (e) {
                 console.error(`Error processing ${file.filename}:`, e.message);
@@ -311,7 +332,10 @@ async function main() {
         const blocks = [];
         for (const example of examples) {
             console.log(`\nProcessing images in ${example.filename}...`);
-            const processed = formatForGitHub(await replaceBase64ImagesWithUploads(example.text, prNumber, token, repositoryId));
+            let processed = example.text;
+            if (processed !== 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ') {
+                processed = formatForGitHub(await replaceBase64ImagesWithUploads(example.text, prNumber, token, repositoryId));
+            }
             blocks.push(`<details>\n<summary>ПРИМЕРЫ_ЗАДАЧ \`${example.filename}\` ${headSha} сборка ${gitStatus}</summary>\n\n${processed}\n\n</details>`);
         }
 

--- a/sh/headless-debug.mjs
+++ b/sh/headless-debug.mjs
@@ -154,6 +154,7 @@ console.log(`Mode: ${headless ? 'headless' : 'visible'}`);
         await page.evaluate(() => {
             const originalCopyToClipboard = window.copyToClipboard;
             window.copyToClipboard = function(text) {
+                window.__latexText = text;
                 console.log('=== LaTeX CODE START ===');
                 console.log(text);
                 console.log('=== LaTeX CODE END ===');
@@ -204,6 +205,7 @@ console.log(`Mode: ${headless ? 'headless' : 'visible'}`);
         // Click LaTeX export button
         await page.evaluate(() => {
             window.__latexExported = false; // Reset flag before export
+            window.__latexText = ''; // Reset text
             if (typeof startQuickExportToTex === 'function') {
                 startQuickExportToTex();
             } else {
@@ -218,6 +220,18 @@ console.log(`Mode: ${headless ? 'headless' : 'visible'}`);
             );
         } catch (error) {
             console.log('Timeout waiting for LaTeX export completion.');
+        }
+
+        const latexText = await page.evaluate(() => window.__latexText || '');
+        const textWithoutBoilerplate = latexText
+            .replace(/Текст задания:/g, '')
+            .replace(/Ответ:/g, '')
+            .replace(/Решение:/g, '')
+            .trim();
+            
+        if (textWithoutBoilerplate.length === 0) {
+            console.log('ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ');
+            break;
         }
     }
     


### PR DESCRIPTION
Починила баг, когда при сбое генерации задачи скрипт выдавал множество пустых примеров (только boilerplate типа 'Текст задания:\n\n\nОтвет:') и продолжал генерацию.

1. `sh/headless-debug.mjs`: теперь при обнаружении, что текст задачи пустой (только boilerplate), скрипт пишет в консоль `ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ` и прерывает цикл итераций (`break`), чтобы не тратить время на заведомо сломанные попытки.
2. `dev/provide_examples_to_PR.mjs`: функция `extractLatex` теперь проверяет наличие строки `ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ` в выводе `headless-debug.mjs`. Также добавлена защита: если LaTeX-блок состоит только из boilerplate без реального текста/ответа/решения, считается, что задача не сгенерировалась. В таких случаях в PR выводится аккуратное сообщение `ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ` вместо простыни из пустых примеров.