### PR TITLE
[script] Остановка генерации и вывод ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ при пустом результате

### DIFF
--- a/dev/provide_examples_to_PR.mjs
+++ b/dev/provide_examples_to_PR.mjs
@@ -100,6 +100,9 @@ async function runDebug(filepath, extraArgs) {
 }
 
 function extractLatex(output) {
+    if (output.includes('ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ')) {
+        return 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ';
+    }
     const regex = /=== LaTeX CODE START ===\r?\n([\s\S]*?)\r?\n=== LaTeX CODE END ===/g;
     const matches = [...output.matchAll(regex)];
     return matches.map((m, i) => `## Пример ${i + 1}\n\n${m[1].trim()}`).filter(text => text.length > 0).join('\n\n---\n\n');
@@ -310,8 +313,13 @@ async function main() {
         // Upload base64 images and replace with URLs
         const blocks = [];
         for (const example of examples) {
-            console.log(`\nProcessing images in ${example.filename}...`);
-            const processed = formatForGitHub(await replaceBase64ImagesWithUploads(example.text, prNumber, token, repositoryId));
+            let processed = example.text;
+            if (processed !== 'ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ') {
+                console.log(`\nProcessing images in ${example.filename}...`);
+                processed = formatForGitHub(await replaceBase64ImagesWithUploads(example.text, prNumber, token, repositoryId));
+            } else {
+                console.log(`\nSkipping image processing for empty task in ${example.filename}.`);
+            }
             blocks.push(`<details>\n<summary>ПРИМЕРЫ_ЗАДАЧ \`${example.filename}\` ${headSha} сборка ${gitStatus}</summary>\n\n${processed}\n\n</details>`);
         }
 

--- a/sh/headless-debug.mjs
+++ b/sh/headless-debug.mjs
@@ -154,6 +154,7 @@ console.log(`Mode: ${headless ? 'headless' : 'visible'}`);
         await page.evaluate(() => {
             const originalCopyToClipboard = window.copyToClipboard;
             window.copyToClipboard = function(text) {
+                window.__lastExportedText = text;
                 console.log('=== LaTeX CODE START ===');
                 console.log(text);
                 console.log('=== LaTeX CODE END ===');
@@ -216,6 +217,27 @@ console.log(`Mode: ${headless ? 'headless' : 'visible'}`);
                 () => window.__latexExported === true,
                 { timeout: 30000 }
             );
+
+            // Check if the generated LaTeX is empty (just headers)
+            const isEmpty = await page.evaluate(() => {
+                const text = window.__lastExportedText || '';
+                let cleaned = text.replace(/Текст задания:\s*/g, '')
+                                  .replace(/Ответ:\s*/g, '')
+                                  .replace(/Решение:\s*/g, '')
+                                  .replace(/\\begin\{tabular\}[\s\S]*?\\end\{tabular\}/g, '')
+                                  .replace(/\\\[|\\\]/g, '')
+                                  .replace(/\$\$/g, '')
+                                  .replace(/\s+/g, '');
+                return cleaned.length === 0;
+            });
+
+            if (isEmpty) {
+                console.log('Empty task detected. Stopping generation.');
+                console.log('=== LaTeX CODE START ===');
+                console.log('ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ');
+                console.log('=== LaTeX CODE END ===');
+                break;
+            }
         } catch (error) {
             console.log('Timeout waiting for LaTeX export completion.');
         }


### PR DESCRIPTION
Привет! Сейчас во время летних каникул как раз занимаюсь айтишными делами, так что с удовольствием пофиксила эту проблему.

**Суть проблемы:**
Если задание в шаблоне не удаётся сгенерировать, `headless-debug.mjs` продолжал выполнять итерации, а на выходе получался массив из пустых шаблонов с заголовками вида `Текст задания:

Ответ:

`. Это засоряло пуллреквесты комментариями без реального контента.

**Что сделано:**
1. **В `sh/headless-debug.mjs`:**
   - Перехватчик `copyToClipboard` теперь дополнительно сохраняет текст в глобальную переменную `window.__lastExportedText`.
   - После каждой итерации генерации добавлена проверка на "пустоту" полученного LaTeX-кода. Из текста удаляются стандартные заголовки (`Текст задания`, `Ответ`, `Решение`), пустые LaTeX-окружения (например, таблицы) и все пробельные символы.
   - Если после очистки остаётся пустая строка, генерация **немедленно прекращается** (`break`), а в лог выводится специальный маркер `ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ`.

2. **В `dev/provide_examples_to_PR.mjs`:**
   - Функция `extractLatex` теперь проверяет наличие маркера `ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ` в выводе. Если маркер найден, она возвращает только эту фразу.
   - При формировании блоков для комментария добавлена проверка: если задача пустая, скрипт пропускает долгий процесс загрузки и замены `base64`-картинок, просто выводя `ЗАДАЧА_НЕ_ГЕНЕРИРУЕТСЯ` под спойлер.

В результате, если хотя бы в одной из попыток генерация выдаёт пустой результат, процесс останавливается, а в PR вместо простыни пустых примеров корректно выводится сообщение о том, что задача не генерируется. 🐈 (Пиксель тоже одобряет этот фикс!)